### PR TITLE
Allow specifying prev_embedding to be adjusted

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+src/bjointsp/results/
 .idea/
 
 # Byte-compiled / optimized / DLL files

--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ B-JointSP is an optimization problem focusing on the joint scaling and placement
 ## Setup
 
 ```
-sudo python3 setup.py install
+python setup.py install
 ```
+Requires Python 3.5+
 
 
 ## Usage

--- a/src/bjointsp/heuristic/heuristic.py
+++ b/src/bjointsp/heuristic/heuristic.py
@@ -127,6 +127,7 @@ def candidate_nodes(start_node, arc, delta_dr, tabu=set()):
 
 
 # return the best node to create an edge to (from a given location, along a given arc, excluding the tabu-instance)
+# FUTURE WORK: favor nodes with suitable instances -> encourage reuse of existing instances -> better objective 2
 def find_best_node(overlay, start_location, arc, delta_dr, fixed, tabu):
     # candidate nodes with enough remaining node capacity
     candidates = candidate_nodes(start_location, arc, delta_dr, tabu)

--- a/src/bjointsp/heuristic/heuristic.py
+++ b/src/bjointsp/heuristic/heuristic.py
@@ -6,7 +6,6 @@ from collections import OrderedDict			# for deterministic behavior
 from bjointsp.overlay.edge import Edge
 from bjointsp.overlay.instance import Instance
 from bjointsp.overlay.overlay import Overlay
-import bjointsp.objective as objective
 
 # global variables for easy access by all functions
 nodes, links, shortest_paths, overlays = None, None, None, None

--- a/src/bjointsp/main.py
+++ b/src/bjointsp/main.py
@@ -25,8 +25,6 @@ def place(network_file, template_file, source_file, fixed_file=None, prev_embedd
     fixed = []
     if fixed_file is not None:
         fixed = reader.read_fixed_instances(fixed_file, components)
-
-    # TODO: read previous embedding
     prev_embedding = {}
     if prev_embedding_file is not None:
         prev_embedding = reader.read_prev_embedding(prev_embedding_file, templates)

--- a/src/bjointsp/main.py
+++ b/src/bjointsp/main.py
@@ -30,6 +30,7 @@ def place(network_file, template_file, source_file, fixed_file=None, prev_embedd
     prev_embedding = {}
     if prev_embedding_file is not None:
         prev_embedding = reader.read_prev_embedding(prev_embedding_file, templates)
+    # FIXME: previous embedding doesn't seem to have an influence!
 
     input_files = [network_file, template_file, source_file, fixed_file]    # TODO: include prev_embedding
     # TODO: support >1 template
@@ -61,12 +62,13 @@ def parse_args():
     parser.add_argument("-t", "--template", help="Template input file (.yaml)", required=True, default=None, dest="template")
     parser.add_argument("-s", "--sources", help="Sources input file (.yaml)", required=True, default=None, dest="sources")
     parser.add_argument("-f", "--fixed", help="Fixed instances input file (.yaml)", required=False, default=None, dest="fixed")
+    parser.add_argument("-p", "--prev", help="Previous embedding input file (.yaml)", required=False, default=None, dest="prev")
     return parser.parse_args()
 
 
 def main():
     args = parse_args()
-    place(args.network, args.template, args.sources, fixed_file=args.fixed, cpu=10, mem=10, dr=50)
+    place(args.network, args.template, args.sources, fixed_file=args.fixed, prev_embedding_file=args.prev, cpu=10, mem=10, dr=50)
 
 
 if __name__ == '__main__':

--- a/src/bjointsp/main.py
+++ b/src/bjointsp/main.py
@@ -16,7 +16,7 @@ obj = objective.COMBINED
 
 
 # solve with heuristic; interface to place-emu: triggers placement
-def place(network_file, template_file, source_file, fixed_file=None, cpu=None, mem=None, dr=None):
+def place(network_file, template_file, source_file, fixed_file=None, prev_embedding_file=None, cpu=None, mem=None, dr=None):
     nodes, links = reader.read_network(network_file, cpu, mem, dr)
     template, source_components = reader.read_template(template_file, return_src_components=True)
     templates = [template]
@@ -25,7 +25,13 @@ def place(network_file, template_file, source_file, fixed_file=None, cpu=None, m
     fixed = []
     if fixed_file is not None:
         fixed = reader.read_fixed_instances(fixed_file, components)
-    input_files = [network_file, template_file, source_file, fixed_file]
+
+    # TODO: read previous embedding
+    prev_embedding = {}
+    if prev_embedding_file is not None:
+        prev_embedding = reader.read_prev_embedding(prev_embedding_file, templates)
+
+    input_files = [network_file, template_file, source_file, fixed_file]    # TODO: include prev_embedding
     # TODO: support >1 template
 
     seed = random.randint(0, 9999)
@@ -43,7 +49,7 @@ def place(network_file, template_file, source_file, fixed_file=None, cpu=None, m
     logging.info("Starting initial embedding at {}".format(timestamp))
     print("Initial embedding\n")
     # TODO: make less verbose or only as verbose when asked for (eg, with -v argument)
-    init_time, runtime, obj_value, changed, overlays = control.solve(nodes, links, templates, {}, sources, fixed, obj)
+    init_time, runtime, obj_value, changed, overlays = control.solve(nodes, links, templates, prev_embedding, sources, fixed, obj)
     result = writer.write_heuristic_result(runtime, obj_value, changed, overlays.values(), input_files, obj, nodes, links, seed, seed_subfolder)
 
     return result

--- a/src/bjointsp/main.py
+++ b/src/bjointsp/main.py
@@ -29,7 +29,7 @@ def place(network_file, template_file, source_file, fixed_file=None, prev_embedd
     if prev_embedding_file is not None:
         prev_embedding = reader.read_prev_embedding(prev_embedding_file, templates)
 
-    input_files = [network_file, template_file, source_file, fixed_file]    # TODO: include prev_embedding
+    input_files = [network_file, template_file, source_file, fixed_file, prev_embedding_file]
     # TODO: support >1 template
 
     seed = random.randint(0, 9999)

--- a/src/bjointsp/main.py
+++ b/src/bjointsp/main.py
@@ -30,7 +30,6 @@ def place(network_file, template_file, source_file, fixed_file=None, prev_embedd
     prev_embedding = {}
     if prev_embedding_file is not None:
         prev_embedding = reader.read_prev_embedding(prev_embedding_file, templates)
-    # FIXME: previous embedding doesn't seem to have an influence!
 
     input_files = [network_file, template_file, source_file, fixed_file]    # TODO: include prev_embedding
     # TODO: support >1 template

--- a/src/bjointsp/parameters/optional/prev.yaml
+++ b/src/bjointsp/parameters/optional/prev.yaml
@@ -75,7 +75,7 @@ placement:
   vnfs:
   - image: '{"image":"placement-apache-img", "network":"(id=input,ip=99.0.0.2/24)"}'
     name: vnf_web
-    node: pop1
+    node: pop2
   - image: '{"image":"placement-fw1-img", "network":"(id=input,ip=88.0.0.2/24),(id=output,ip=99.0.0.1/24)"}'
     name: vnf_fw1
     node: pop0

--- a/src/bjointsp/parameters/optional/prev.yaml
+++ b/src/bjointsp/parameters/optional/prev.yaml
@@ -1,0 +1,85 @@
+input:
+  algorithm: bjointsp
+  network: Abilene.graphml
+  num_edges: 14
+  num_nodes: 11
+  num_sources: 1
+  num_vnfs: 3
+  objective: 0
+  seed: 3805
+  service: fw1chain.yaml
+  sources: source0.yaml
+metrics:
+  changed:
+  - name: vnf_web
+    node: pop0
+  - name: vnf_fw1
+    node: pop0
+  - name: vnf_user
+    node: pop0
+  delays:
+  - delay: 0
+    dest: vnf_fw1
+    dest_node: pop0
+    src: vnf_user
+    src_node: pop0
+  - delay: 0
+    dest: vnf_web
+    dest_node: pop0
+    src: vnf_fw1
+    src_node: pop0
+  max_cpu_oversub: 0
+  max_dr_oversub: 0
+  max_mem_oversub: 0
+  num_changed: 3
+  num_instances: 3
+  obj_value: 3004000
+  runtime: 0.09373068809509277
+  total_delay: 0
+placement:
+  alloc_node_res:
+  - cpu: 1
+    mem: 1
+    name: vnf_web
+    node: pop0
+  - cpu: 1
+    mem: 1
+    name: vnf_fw1
+    node: pop0
+  - cpu: 0
+    mem: 0
+    name: vnf_user
+    node: pop0
+  cpu_oversub: []
+  dr_oversub: []
+  flows:
+  - arc: vnf_user.0->vnf_fw1.0
+    dst_node: pop0
+    flow_id: f1
+    src_node: pop0
+  - arc: vnf_fw1.0->vnf_web.0
+    dst_node: pop0
+    flow_id: f1
+    src_node: pop0
+  links: []
+  mem_oversub: []
+  vlinks:
+  - dest_node: pop0
+    dest_vnf: vnf_fw1
+    src_node: pop0
+    src_vnf: vnf_user
+  - dest_node: pop0
+    dest_vnf: vnf_web
+    src_node: pop0
+    src_vnf: vnf_fw1
+  vnfs:
+  - image: '{"image":"placement-apache-img", "network":"(id=input,ip=99.0.0.2/24)"}'
+    name: vnf_web
+    node: pop1
+  - image: '{"image":"placement-fw1-img", "network":"(id=input,ip=88.0.0.2/24),(id=output,ip=99.0.0.1/24)"}'
+    name: vnf_fw1
+    node: pop0
+  - image: '{"image":"placement-user-img", "network":"(id=output,ip=10.0.0.1/24)"}'
+    name: vnf_user
+    node: pop0
+time: 2018-07-24_16-32-07

--- a/src/bjointsp/read_write/reader.py
+++ b/src/bjointsp/read_write/reader.py
@@ -179,8 +179,6 @@ def read_prev_embedding(file, templates):
     for t in templates:
         prev_embedding[t] = Overlay(t, [], [])
 
-       # TODO: how to know which VNF belongs to which template? how to create matching overlays?
-
     with open(file, "r") as f:
         yaml_file = yaml.load(f)
 
@@ -192,8 +190,7 @@ def read_prev_embedding(file, templates):
                 # use first matching component (assuming it's only in one template)
                 if vnf["name"] in [c.name for c in t.components]:
                     component = list(filter(lambda x: x.name == vnf["name"], t.components))[0]
-                    # add new instance to overlay of corresponding template
-                    # TODO: can I just take vnf[node] as location? and empty source flows?
+                    # add new instance to overlay of corresponding template (source components need src_flows being set)
                     if component.source:
                         prev_embedding[t].instances.append(Instance(component, vnf["node"], src_flows=[]))
                     else:

--- a/src/bjointsp/read_write/reader.py
+++ b/src/bjointsp/read_write/reader.py
@@ -12,6 +12,7 @@ from bjointsp.template.component import Component
 from bjointsp.template.template import Template
 from bjointsp.overlay.overlay import Overlay
 from bjointsp.overlay.instance import Instance
+from bjointsp.overlay.edge import Edge
 
 
 # remove empty values (from multiple delimiters in a row)
@@ -185,7 +186,6 @@ def read_prev_embedding(file, templates):
         # read and create VNF instances of previous embedding
         for vnf in yaml_file["placement"]["vnfs"]:
             # find component that matches the VNF name (in any of the templates)
-            component = None
             for t in templates:
                 # use first matching component (assuming it's only in one template)
                 if vnf["name"] in [c.name for c in t.components]:
@@ -197,6 +197,26 @@ def read_prev_embedding(file, templates):
                         prev_embedding[t].instances.append(Instance(component, vnf["node"]))
                     break
 
-        # TODO: add edges
+        # TODO: read and create flows. otherwise, adding edges really doesn't make a difference in the heuristic
+        # read and create edges of previous embedding
+        for edge in yaml_file["placement"]["vlinks"]:
+            instances = [i for ol in prev_embedding.values() for i in ol.instances]
+
+            # try to get source and dest instance from list of instances
+            try:
+                source = list(filter(lambda x: x.component.name == edge["src_vnf"] and x.location == edge["src_node"], instances))[0]
+                dest = list(filter(lambda x: x.component.name == edge["dest_vnf"] and x.location == edge["dest_node"], instances))[0]
+            # if the vnfs don't exist in prev_embedding (eg, through incorrect input), ignore the edge
+            except IndexError:
+                print("No matching VNFs in prev_embedding for edge from {} to {}. Ignoring the edge.".format(source, dest))
+                continue    # skip and continue with next edge
+
+            # get arc from templates by matching against source and dest components
+            for t in templates:
+                if source.component in t.components and dest.component in t.components:
+                    # assume t has an arc source->dest if both components are in t
+                    arc = list(filter(lambda x: x.source == source.component and x.dest == dest.component, t.arcs))[0]
+                    # add new edge to overlay of corresponding template
+                    prev_embedding[t].edges.append(Edge(arc, source, dest))
 
     return prev_embedding

--- a/src/bjointsp/read_write/reader.py
+++ b/src/bjointsp/read_write/reader.py
@@ -174,9 +174,12 @@ def read_fixed_instances(file, components):
 
 # read previous embedding from yaml file
 def read_prev_embedding(file, templates):
+    # create empty overlays for all templates
     prev_embedding = {}         # dict: template -> overlay
-    instances = []
-    # TODO: how to know which VNF belongs to which template? how to create matching overlays?
+    for t in templates:
+        prev_embedding[t] = Overlay(t, [], [])
+
+       # TODO: how to know which VNF belongs to which template? how to create matching overlays?
 
     with open(file, "r") as f:
         yaml_file = yaml.load(f)
@@ -189,13 +192,14 @@ def read_prev_embedding(file, templates):
                 # use first matching component (assuming it's only in one template)
                 if vnf["name"] in [c.name for c in t.components]:
                     component = list(filter(lambda x: x.name == vnf["name"], t.components))[0]
+                    # add new instance to overlay of corresponding template
+                    # TODO: can I just take vnf[node] as location? and empty source flows?
+                    if component.source:
+                        prev_embedding[t].instances.append(Instance(component, vnf["node"], src_flows=[]))
+                    else:
+                        prev_embedding[t].instances.append(Instance(component, vnf["node"]))
                     break
-            if component is None:
-                raise ValueError("No matching component in given templates found for {}".format(vnf["name"]))
 
-            # TODO: can I just take vnf[node] as location?
-            instances.append(Instance(component, vnf["node"]))
-
-        # TODO: add edges, create overlay, add to prev_embedding
+        # TODO: add edges
 
     return prev_embedding

--- a/src/bjointsp/read_write/reader.py
+++ b/src/bjointsp/read_write/reader.py
@@ -10,6 +10,8 @@ from bjointsp.overlay.flow import Flow
 from bjointsp.template.arc import Arc
 from bjointsp.template.component import Component
 from bjointsp.template.template import Template
+from bjointsp.overlay.overlay import Overlay
+from bjointsp.overlay.instance import Instance
 
 
 # remove empty values (from multiple delimiters in a row)
@@ -168,3 +170,32 @@ def read_fixed_instances(file, components):
 
             fixed_instances.append(FixedInstance(i["node"], component))
     return fixed_instances
+
+
+# read previous embedding from yaml file
+def read_prev_embedding(file, templates):
+    prev_embedding = {}         # dict: template -> overlay
+    instances = []
+    # TODO: how to know which VNF belongs to which template? how to create matching overlays?
+
+    with open(file, "r") as f:
+        yaml_file = yaml.load(f)
+
+        # read and create VNF instances of previous embedding
+        for vnf in yaml_file["placement"]["vnfs"]:
+            # find component that matches the VNF name (in any of the templates)
+            component = None
+            for t in templates:
+                # use first matching component (assuming it's only in one template)
+                if vnf["name"] in [c.name for c in t.components]:
+                    component = list(filter(lambda x: x.name == vnf["name"], t.components))[0]
+                    break
+            if component is None:
+                raise ValueError("No matching component in given templates found for {}".format(vnf["name"]))
+
+            # TODO: can I just take vnf[node] as location?
+            instances.append(Instance(component, vnf["node"]))
+
+        # TODO: add edges, create overlay, add to prev_embedding
+
+    return prev_embedding

--- a/src/bjointsp/read_write/writer.py
+++ b/src/bjointsp/read_write/writer.py
@@ -128,11 +128,19 @@ def write_heuristic_result(runtime, obj_value, changed, overlays, input_files, o
               "input": {"network": os.path.basename(input_files[0]),
                         "service": os.path.basename(input_files[1]),
                         "sources": os.path.basename(input_files[2]),
+                        "fixed": "None",
+                        "prev_embedding": "None",
                         "seed": seed,
                         "algorithm": "bjointsp",
                         "objective": obj},
               "metrics": {"runtime": runtime,
                           "obj_value": obj_value}}
+
+    # set file of fixed instances and of previous embedding if they are specified
+    if input_files[3] is not None:
+        result["input"]["fixed"] = os.path.basename(input_files[3])
+    if input_files[4] is not None:
+        result["input"]["prev_embedding"] = os.path.basename(input_files[4])
 
     # add input details to simplify evaluation: network size, etc
     network = nx.read_graphml(input_files[0])


### PR DESCRIPTION
The previous embedding has to be a yaml file in the format of the result yaml files created by the heuristic. Specifically, it has to include a section with VNFs and vLinks.

This prev_embedding file is parsed to recreate an overlay, representing the previous embedding, which is then adjusted by the heuristic. Currently only vnfs and vlinks/edges are recreated. Not flows mapped to the vlinks.

Closes #2 