### PR TITLE
VNF delays

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-# Modifications by Haydar Qarawlus and Adnan 
 from setuptools import setup, find_packages
 
 setup(name='bjointsp',

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+# Modifications by Haydar Qarawlus and Adnan 
 from setuptools import setup, find_packages
 
 setup(name='bjointsp',

--- a/src/bjointsp/heuristic/control.py
+++ b/src/bjointsp/heuristic/control.py
@@ -77,6 +77,9 @@ def objective_value(overlays, print_info=False):
     for i in curr_instances:
         vnf_delays += i.component.vnf_delay
 
+    # adding vnf_delay to total_delay
+    total_delay += vnf_delays
+    
     # calculate total consumed resources
     total_consumed_cpu = sum(consumed_cpu[v] for v in nodes.ids)
     total_consumed_mem = sum(consumed_mem[v] for v in nodes.ids)
@@ -116,7 +119,7 @@ def objective_value(overlays, print_info=False):
 
     # minimize total delay
     elif obj == objective.DELAY:
-        value = total_delay+vnf_delays
+        value = total_delay
 
     else:
         logging.error("Objective {} unknown".format(obj))

--- a/src/bjointsp/heuristic/control.py
+++ b/src/bjointsp/heuristic/control.py
@@ -159,7 +159,7 @@ def solve(arg_nodes, arg_links, templates, prev_overlays, sources, fixed, arg_ob
 
     # sort templates with decreasing weight: heaviest/most difficult templates get embedded first
     # Modify 'False' in weight function call to True to weight vnf delays as well. 
-    templates.sort(key=lambda t: t.weight(src_drs[t.source()], False), reverse=True)
+    templates.sort(key=lambda t: t.weight(src_drs[t.source()]), reverse=True)
     print("Templates sorted to start with heaviest:", *templates, sep=" ")
 
     # initial solution

--- a/src/bjointsp/heuristic/control.py
+++ b/src/bjointsp/heuristic/control.py
@@ -158,7 +158,8 @@ def solve(arg_nodes, arg_links, templates, prev_overlays, sources, fixed, arg_ob
         src_drs[src.component] += src.total_flow_dr()
 
     # sort templates with decreasing weight: heaviest/most difficult templates get embedded first
-    templates.sort(key=lambda t: t.weight(src_drs[t.source()]), reverse=True)
+    # Modify 'False' in weight function call to True to weight vnf delays as well. 
+    templates.sort(key=lambda t: t.weight(src_drs[t.source()], False), reverse=True)
     print("Templates sorted to start with heaviest:", *templates, sep=" ")
 
     # initial solution

--- a/src/bjointsp/main.py
+++ b/src/bjointsp/main.py
@@ -20,6 +20,8 @@ def place(network_file, template_file, source_file, fixed_file=None, prev_embedd
     nodes, links = reader.read_network(network_file, cpu, mem, dr)
     template, source_components = reader.read_template(template_file, return_src_components=True)
     templates = [template]
+    # print(template)
+    # exit()
     sources = reader.read_sources(source_file, source_components)
     components = {j for t in templates for j in t.components}
     fixed = []

--- a/src/bjointsp/main.py
+++ b/src/bjointsp/main.py
@@ -17,6 +17,17 @@ obj = objective.COMBINED
 
 # solve with heuristic; interface to place-emu: triggers placement
 def place(network_file, template_file, source_file, fixed_file=None, prev_embedding_file=None, cpu=None, mem=None, dr=None):
+    seed = random.randint(0, 9999)
+    seed_subfolder = False
+    random.seed(seed)
+
+    # set up logging into file Data/logs/heuristic/scenario_timestamp_seed.log
+    # logging.disable(logging.CRITICAL)     # disable logging
+    timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+    os.makedirs("logs/heuristic/obj{}".format(obj), exist_ok=True)
+    logging.basicConfig(filename="logs/heuristic/obj{}/{}_{}_{}.log".format(obj, os.path.basename(network_file)[:-4], timestamp, seed),
+                        level=logging.DEBUG, format="%(asctime)s(%(levelname)s):\t%(message)s", datefmt="%H:%M:%S")
+
     nodes, links = reader.read_network(network_file, cpu, mem, dr)
     template, source_components = reader.read_template(template_file, return_src_components=True)
     templates = [template]
@@ -34,17 +45,9 @@ def place(network_file, template_file, source_file, fixed_file=None, prev_embedd
     input_files = [network_file, template_file, source_file, fixed_file, prev_embedding_file]
     # TODO: support >1 template
 
-    seed = random.randint(0, 9999)
-    seed_subfolder = False
-    random.seed(seed)
+   
     print("Using seed {}".format(seed))
 
-    # set up logging into file Data/logs/heuristic/scenario_timestamp_seed.log
-    # logging.disable(logging.CRITICAL)		# disable logging
-    timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-    os.makedirs("logs/heuristic/obj{}".format(obj), exist_ok=True)
-    logging.basicConfig(filename="logs/heuristic/obj{}/{}_{}_{}.log".format(obj, os.path.basename(network_file)[:-4], timestamp, seed),
-                        level=logging.DEBUG, format="%(asctime)s(%(levelname)s):\t%(message)s", datefmt="%H:%M:%S")
 
     logging.info("Starting initial embedding at {}".format(timestamp))
     print("Initial embedding\n")

--- a/src/bjointsp/network/nodes.py
+++ b/src/bjointsp/network/nodes.py
@@ -1,6 +1,5 @@
 class Nodes:
-    def __init__(self, ids, cpu, mem, delay):
+    def __init__(self, ids, cpu, mem):
         self.ids = ids
         self.cpu = cpu
         self.mem = mem
-        self.delay = delay

--- a/src/bjointsp/network/nodes.py
+++ b/src/bjointsp/network/nodes.py
@@ -1,5 +1,6 @@
 class Nodes:
-    def __init__(self, ids, cpu, mem):
+    def __init__(self, ids, cpu, mem, delay):
         self.ids = ids
         self.cpu = cpu
         self.mem = mem
+        self.delay = delay

--- a/src/bjointsp/parameters/sources/source0.yaml
+++ b/src/bjointsp/parameters/sources/source0.yaml
@@ -3,3 +3,15 @@
   flows:
     - id: f1
       data_rate: 1
+# - node: pop1
+#   vnf: vnf_user
+#   flows:
+#     - id: f2
+#       data_rate: 1
+# - node: pop2
+#   vnf: vnf_user
+#   flows:
+#     - id: f3
+#       data_rate: 3
+#     - id: f4
+#       data_rate: 3

--- a/src/bjointsp/parameters/sources/source0.yaml
+++ b/src/bjointsp/parameters/sources/source0.yaml
@@ -3,15 +3,3 @@
   flows:
     - id: f1
       data_rate: 1
-# - node: pop1
-#   vnf: vnf_user
-#   flows:
-#     - id: f2
-#       data_rate: 1
-# - node: pop2
-#   vnf: vnf_user
-#   flows:
-#     - id: f3
-#       data_rate: 3
-#     - id: f4
-#       data_rate: 3

--- a/src/bjointsp/parameters/templates/fw1chain.yaml
+++ b/src/bjointsp/parameters/templates/fw1chain.yaml
@@ -9,7 +9,7 @@ vnfs:
     inputs_bwd: 0
     outputs_fwd: 1
     outputs_bwd: 0
-    cpu: [1]
+    cpu: [0]
     mem: [0]
     vnf_delay: 0
     out_fwd: []

--- a/src/bjointsp/parameters/templates/fw1chain.yaml
+++ b/src/bjointsp/parameters/templates/fw1chain.yaml
@@ -11,29 +11,22 @@ vnfs:
     outputs_bwd: 0
     cpu: [1]
     mem: [0]
-    vnf_delay: 50
+    vnf_delay: 0
     out_fwd: []
     out_bwd: []
     image: '{"image":"placement-user-img", "network":"(id=output,ip=10.0.0.1/24)"}'
   - name: vnf_fw1
     type: normal
     stateful: False
-    # inputs_fwd: 2
     inputs_fwd: 1
     inputs_bwd: 0
-    # outputs_fwd: 3
     outputs_fwd: 1
     outputs_bwd: 0
-    # cpu: [1,3,0]
-    # mem: [1,5,0]
     cpu: [1,0]
     mem: [1,0]
     vnf_delay: 35
     out_fwd:
         - [1,0]
-      # - [1,1,0]
-      # - [2,5,2]
-      # - [6,4,2]
     out_bwd: []
     image: '{"image":"placement-fw1-img", "network":"(id=input,ip=88.0.0.2/24),(id=output,ip=99.0.0.1/24)"}'
   - name: vnf_web

--- a/src/bjointsp/parameters/templates/fw1chain.yaml
+++ b/src/bjointsp/parameters/templates/fw1chain.yaml
@@ -9,22 +9,31 @@ vnfs:
     inputs_bwd: 0
     outputs_fwd: 1
     outputs_bwd: 0
-    cpu: [0]
+    cpu: [1]
     mem: [0]
+    vnf_delay: 50
     out_fwd: []
     out_bwd: []
     image: '{"image":"placement-user-img", "network":"(id=output,ip=10.0.0.1/24)"}'
   - name: vnf_fw1
     type: normal
     stateful: False
+    # inputs_fwd: 2
     inputs_fwd: 1
     inputs_bwd: 0
+    # outputs_fwd: 3
     outputs_fwd: 1
     outputs_bwd: 0
+    # cpu: [1,3,0]
+    # mem: [1,5,0]
     cpu: [1,0]
     mem: [1,0]
+    vnf_delay: 35
     out_fwd:
-      - [1,0]
+        - [1,0]
+      # - [1,1,0]
+      # - [2,5,2]
+      # - [6,4,2]
     out_bwd: []
     image: '{"image":"placement-fw1-img", "network":"(id=input,ip=88.0.0.2/24),(id=output,ip=99.0.0.1/24)"}'
   - name: vnf_web
@@ -36,6 +45,7 @@ vnfs:
     outputs_bwd: 0
     cpu: [1,0]
     mem: [1,0]
+    vnf_delay: 20
     out_fwd: []
     out_bwd: []
     image: '{"image":"placement-apache-img", "network":"(id=input,ip=99.0.0.2/24)"}'

--- a/src/bjointsp/read_write/reader.py
+++ b/src/bjointsp/read_write/reader.py
@@ -113,11 +113,12 @@ def read_template(file, return_src_components=False):
             inputs = (vnf["inputs_fwd"], vnf["inputs_bwd"])
             outputs = (vnf["outputs_fwd"], vnf["outputs_bwd"])
             outgoing = (vnf["out_fwd"], vnf["out_bwd"])
-            print("PROC DELAY")
+            # print("PROC DELAY")
             # Getting the VNF delay from YAML, checking to see if key exists, otherwise set default 0
             vnf_delay = vnf.get("vnf_delay",0)
-
-            component = Component(vnf["name"], vnf["type"], vnf["stateful"], inputs, outputs, vnf["cpu"], vnf["mem"], outgoing, vnf["image"],vnf_delay)
+            # print(vnf_delay)
+            # exit()
+            component = Component(vnf["name"], vnf["type"], vnf["stateful"], inputs, outputs, vnf["cpu"], vnf["mem"], outgoing, vnf_delay, vnf["image"])
             components.append(component)
 
         for arc in template["vlinks"]:

--- a/src/bjointsp/read_write/reader.py
+++ b/src/bjointsp/read_write/reader.py
@@ -13,6 +13,7 @@ from bjointsp.template.template import Template
 from bjointsp.overlay.overlay import Overlay
 from bjointsp.overlay.instance import Instance
 from bjointsp.overlay.edge import Edge
+import logging
 
 
 # remove empty values (from multiple delimiters in a row)
@@ -113,11 +114,12 @@ def read_template(file, return_src_components=False):
             inputs = (vnf["inputs_fwd"], vnf["inputs_bwd"])
             outputs = (vnf["outputs_fwd"], vnf["outputs_bwd"])
             outgoing = (vnf["out_fwd"], vnf["out_bwd"])
-            # print("PROC DELAY")
             # Getting the VNF delay from YAML, checking to see if key exists, otherwise set default 0
             vnf_delay = vnf.get("vnf_delay",0)
-            # print(vnf_delay)
-            # exit()
+             # Check whether vnf is source and has cpu and mem requirements. 
+            if (vnf["type"] == "source") and ((len(vnf["cpu"]) == 1 and (vnf["cpu"][0] > 0)) or (len(vnf["mem"]) == 1 and (vnf["mem"][0] > 0))):
+                logging.info("\tSource component {} has CPU:{} and MEM:{} requirements. Check the template file".format(vnf['name'], vnf['cpu'], vnf['mem']))
+                print ("Source component {} has CPU:{} and MEM:{} requirements. Check the template file".format(vnf['name'], vnf['cpu'], vnf['mem']))
             component = Component(vnf["name"], vnf["type"], vnf["stateful"], inputs, outputs, vnf["cpu"], vnf["mem"], outgoing, vnf_delay, vnf["image"])
             components.append(component)
 

--- a/src/bjointsp/read_write/reader.py
+++ b/src/bjointsp/read_write/reader.py
@@ -113,7 +113,11 @@ def read_template(file, return_src_components=False):
             inputs = (vnf["inputs_fwd"], vnf["inputs_bwd"])
             outputs = (vnf["outputs_fwd"], vnf["outputs_bwd"])
             outgoing = (vnf["out_fwd"], vnf["out_bwd"])
-            component = Component(vnf["name"], vnf["type"], vnf["stateful"], inputs, outputs, vnf["cpu"], vnf["mem"], outgoing, vnf["image"])
+            print("PROC DELAY")
+            # Getting the VNF delay from YAML, checking to see if key exists, otherwise set default 0
+            vnf_delay = vnf.get("vnf_delay",0)
+
+            component = Component(vnf["name"], vnf["type"], vnf["stateful"], inputs, outputs, vnf["cpu"], vnf["mem"], outgoing, vnf["image"],vnf_delay)
             components.append(component)
 
         for arc in template["vlinks"]:

--- a/src/bjointsp/read_write/writer.py
+++ b/src/bjointsp/read_write/writer.py
@@ -90,7 +90,7 @@ def save_heuristic_variables(result, changed_instances, instances, edges, nodes,
             result["placement"]["flows"].append(flow)
         for path in e.paths:
             # record edge delay: all flows take the same (shortest) path => take path delay
-            delay = {"src": e.arc.source.name, "dest": e.arc.dest.name, "src_node": e.source.location, "dest_node": e.dest.location, "delay": sp.path_delay(links, path), "src_vnf_delay": e.arc.source.vnf_delay, "dest_vnf_delay": e.arc.dest.vnf_delay }
+            delay = {"src": e.arc.source.name, "dest": e.arc.dest.name, "src_node": e.source.location, "dest_node": e.dest.location, "path_delay": sp.path_delay(links, path), "src_vnf_delay": e.arc.source.vnf_delay, "dest_vnf_delay": e.arc.dest.vnf_delay }
             result["metrics"]["delays"].append(delay)
             result["metrics"]["total_delay"] += sp.path_delay(links, path)+e.arc.source.vnf_delay+e.arc.dest.vnf_delay
 

--- a/src/bjointsp/read_write/writer.py
+++ b/src/bjointsp/read_write/writer.py
@@ -90,9 +90,9 @@ def save_heuristic_variables(result, changed_instances, instances, edges, nodes,
             result["placement"]["flows"].append(flow)
         for path in e.paths:
             # record edge delay: all flows take the same (shortest) path => take path delay
-            delay = {"src": e.arc.source.name, "dest": e.arc.dest.name, "src_node": e.source.location, "dest_node": e.dest.location, "delay": sp.path_delay(links, path)}
+            delay = {"src": e.arc.source.name, "dest": e.arc.dest.name, "src_node": e.source.location, "dest_node": e.dest.location, "delay": sp.path_delay(links, path), "src_vnf_delay": e.arc.source.vnf_delay, "dest_vnf_delay": e.arc.dest.vnf_delay }
             result["metrics"]["delays"].append(delay)
-            result["metrics"]["total_delay"] += sp.path_delay(links, path)
+            result["metrics"]["total_delay"] += sp.path_delay(links, path)+e.arc.source.vnf_delay+e.arc.dest.vnf_delay
 
             # go through nodes of each path and increase the dr of the traversed links
             for i in range(len(path) - 1):

--- a/src/bjointsp/read_write/writer.py
+++ b/src/bjointsp/read_write/writer.py
@@ -84,6 +84,7 @@ def save_heuristic_variables(result, changed_instances, instances, edges, nodes,
     result["metrics"]["vnf_delays"] = []
     result["metrics"]["total_path_delay"] = 0
     result["metrics"]["total_vnf_delay"] = 0
+    result['metrics']["total_delay"] = 0
     result["placement"]["links"] = []
     consumed_dr = defaultdict(int)		# default = 0
     for e in edges:
@@ -95,6 +96,7 @@ def save_heuristic_variables(result, changed_instances, instances, edges, nodes,
             path_delay = {"src": e.arc.source.name, "dest": e.arc.dest.name, "src_node": e.source.location, "dest_node": e.dest.location, "path_delay": sp.path_delay(links, path)}
             result["metrics"]["path_delays"].append(path_delay)
             result["metrics"]["total_path_delay"] += sp.path_delay(links, path)
+            result["metrics"]["total_delay"] += sp.path_delay(links, path)
 
             # go through nodes of each path and increase the dr of the traversed links
             for i in range(len(path) - 1):
@@ -105,9 +107,10 @@ def save_heuristic_variables(result, changed_instances, instances, edges, nodes,
                     result["placement"]["links"].append(link)
         for path in e.paths:
             # record vnf delays
-            vnf_delay = {"dest_vnf": e.arc.dest.name, "dest_vnf_delay": e.arc.dest.vnf_delay }
+            vnf_delay = {"vnf": e.arc.dest.name, "vnf_delay": e.arc.dest.vnf_delay }
             result["metrics"]["vnf_delays"].append(vnf_delay)
             result["metrics"]["total_vnf_delay"] += e.arc.dest.vnf_delay
+            result["metrics"]["total_delay"] += e.arc.dest.vnf_delay
 
 
     # link capacity violations

--- a/src/bjointsp/read_write/writer.py
+++ b/src/bjointsp/read_write/writer.py
@@ -80,8 +80,10 @@ def save_heuristic_variables(result, changed_instances, instances, edges, nodes,
 
     # edge and link data rate, used links
     result["placement"]["flows"] = []
-    result["metrics"]["delays"] = []
-    result["metrics"]["total_delay"] = 0
+    result["metrics"]["path_delays"] = []
+    result["metrics"]["vnf_delays"] = []
+    result["metrics"]["total_path_delay"] = 0
+    result["metrics"]["total_vnf_delay"] = 0
     result["placement"]["links"] = []
     consumed_dr = defaultdict(int)		# default = 0
     for e in edges:
@@ -90,9 +92,9 @@ def save_heuristic_variables(result, changed_instances, instances, edges, nodes,
             result["placement"]["flows"].append(flow)
         for path in e.paths:
             # record edge delay: all flows take the same (shortest) path => take path delay
-            delay = {"src": e.arc.source.name, "dest": e.arc.dest.name, "src_node": e.source.location, "dest_node": e.dest.location, "path_delay": sp.path_delay(links, path), "src_vnf_delay": e.arc.source.vnf_delay, "dest_vnf_delay": e.arc.dest.vnf_delay }
-            result["metrics"]["delays"].append(delay)
-            result["metrics"]["total_delay"] += sp.path_delay(links, path)+e.arc.source.vnf_delay+e.arc.dest.vnf_delay
+            path_delay = {"src": e.arc.source.name, "dest": e.arc.dest.name, "src_node": e.source.location, "dest_node": e.dest.location, "path_delay": sp.path_delay(links, path)}
+            result["metrics"]["path_delays"].append(path_delay)
+            result["metrics"]["total_path_delay"] += sp.path_delay(links, path)
 
             # go through nodes of each path and increase the dr of the traversed links
             for i in range(len(path) - 1):
@@ -101,6 +103,12 @@ def save_heuristic_variables(result, changed_instances, instances, edges, nodes,
                     consumed_dr[(path[i], path[i+1])] += e.flow_dr() / len(e.paths)
                     link = {"arc": str(e.arc), "edge_src": e.source.location, "edge_dst": e.dest.location, "link_src": path[i], "link_dst": path[i+1]}
                     result["placement"]["links"].append(link)
+        for path in e.paths:
+            # record vnf delays
+            vnf_delay = {"dest_vnf": e.arc.dest.name, "dest_vnf_delay": e.arc.dest.vnf_delay }
+            result["metrics"]["vnf_delays"].append(vnf_delay)
+            result["metrics"]["total_vnf_delay"] += e.arc.dest.vnf_delay
+
 
     # link capacity violations
     result["placement"]["dr_oversub"] = []

--- a/src/bjointsp/template/component.py
+++ b/src/bjointsp/template/component.py
@@ -1,5 +1,5 @@
 class Component:
-    def __init__(self, name, type, stateful, inputs, outputs, cpu, mem, dr, config=None):
+    def __init__(self, name, type, stateful, inputs, outputs, cpu, mem, dr, vnf_delay, config=None):
         self.name = name
         if type == "source":
             self.source = True
@@ -19,6 +19,7 @@ class Component:
         self.outputs_back = outputs[1]
         self.cpu = cpu      # function of forward and backward ingoing data rates
         self.mem = mem
+        self.vnf_delay = vnf_delay
         self.dr = dr[0]
         self.dr_back = dr[1]
         self.config = config		# config used by external apps/MANOs (describes image, ports, ...)
@@ -94,6 +95,18 @@ class Component:
             requirement = 0
         for i in range(inputs):
             requirement += self.mem[i] * incoming[i]    # linear function
+
+        return requirement
+    def delay_req(self, incoming, ignore_idle=None):
+        inputs = self.inputs + self.inputs_back
+        if len(incoming) != inputs:
+            raise ValueError("Mismatch of #incoming data rates and inputs")
+
+        requirement = self.delay[-1]  # idle consumption
+        if self == ignore_idle:
+            requirement = 0
+        for i in range(inputs):
+            requirement += self.delay[i] * incoming[i]    # linear function
 
         return requirement
 

--- a/src/bjointsp/template/component.py
+++ b/src/bjointsp/template/component.py
@@ -25,6 +25,8 @@ class Component:
         self.config = config		# config used by external apps/MANOs (describes image, ports, ...)
 
         total_inputs = self.inputs + self.inputs_back
+
+        # What is this used for? For every input we need a total of 1 CPU and 1 Mem? 
         if len(self.cpu) != total_inputs + 1: # always need idle consumption (can be 0)
             raise ValueError("Inputs and CPU function mismatch or missing idle consumption")
         if len(self.mem) != total_inputs + 1:
@@ -54,6 +56,10 @@ class Component:
 
     def __hash__(self):
         return hash((self.name))
+
+
+    def get_delay(self):
+        return self.vnf_delay
 
     def print(self):
         if self.source:
@@ -97,18 +103,18 @@ class Component:
             requirement += self.mem[i] * incoming[i]    # linear function
 
         return requirement
-    def delay_req(self, incoming, ignore_idle=None):
-        inputs = self.inputs + self.inputs_back
-        if len(incoming) != inputs:
-            raise ValueError("Mismatch of #incoming data rates and inputs")
+    # def delay_req(self, incoming, ignore_idle=None):
+    #     inputs = self.inputs + self.inputs_back
+    #     if len(incoming) != inputs:
+    #         raise ValueError("Mismatch of #incoming data rates and inputs")
 
-        requirement = self.delay[-1]  # idle consumption
-        if self == ignore_idle:
-            requirement = 0
-        for i in range(inputs):
-            requirement += self.delay[i] * incoming[i]    # linear function
+    #     requirement = self.delay[-1]  # idle consumption
+    #     if self == ignore_idle:
+    #         requirement = 0
+    #     for i in range(inputs):
+    #         requirement += self.delay[i] * incoming[i]    # linear function
 
-        return requirement
+    #     return requirement
 
     # outgoing data rate at specified output based on the incoming data rates
     def outgoing(self, in_vector, output):

--- a/src/bjointsp/template/component.py
+++ b/src/bjointsp/template/component.py
@@ -1,5 +1,5 @@
 class Component:
-    def __init__(self, name, type, stateful, inputs, outputs, cpu, mem, dr, vnf_delay, config=None):
+    def __init__(self, name, type, stateful, inputs, outputs, cpu, mem, dr, vnf_delay=0, config=None):
         self.name = name
         if type == "source":
             self.source = True
@@ -26,7 +26,6 @@ class Component:
 
         total_inputs = self.inputs + self.inputs_back
 
-        # What is this used for? For every input we need a total of 1 CPU and 1 Mem? 
         if len(self.cpu) != total_inputs + 1: # always need idle consumption (can be 0)
             raise ValueError("Inputs and CPU function mismatch or missing idle consumption")
         if len(self.mem) != total_inputs + 1:
@@ -56,10 +55,6 @@ class Component:
 
     def __hash__(self):
         return hash((self.name))
-
-
-    def get_delay(self):
-        return self.vnf_delay
 
     def print(self):
         if self.source:
@@ -103,18 +98,6 @@ class Component:
             requirement += self.mem[i] * incoming[i]    # linear function
 
         return requirement
-    # def delay_req(self, incoming, ignore_idle=None):
-    #     inputs = self.inputs + self.inputs_back
-    #     if len(incoming) != inputs:
-    #         raise ValueError("Mismatch of #incoming data rates and inputs")
-
-    #     requirement = self.delay[-1]  # idle consumption
-    #     if self == ignore_idle:
-    #         requirement = 0
-    #     for i in range(inputs):
-    #         requirement += self.delay[i] * incoming[i]    # linear function
-
-    #     return requirement
 
     # outgoing data rate at specified output based on the incoming data rates
     def outgoing(self, in_vector, output):

--- a/src/bjointsp/template/template.py
+++ b/src/bjointsp/template/template.py
@@ -42,18 +42,27 @@ class Template:
         return None
 
     # weight = expected resource consumption based on total source data rate and components
-    def weight(self, src_dr):
+    def weight(self, src_dr, delay_calc=False):
         # outgoing data rate of specified component in specified direction and from specified output
         out_dr = {}
 
         # iterate over components in topological order, determine outgoing dr for each and store it in out_dr
         # first, consider only forward direction then only backward
         # also determine cpu/mem consumption per component and direction and increase total_cpu/mem accordingly
-        total_cpu, total_mem = 0, 0
+        total_cpu, total_mem, total_delay = 0, 0, 0
         topo_order = self.topological_component_order()
         direction = "forward"
         end_reached = False
         for j in topo_order:
+
+            # I calculate here the delay regardless of direction or whether src or end (total in both direction). Comments on this? 
+            # Will change placement result - adds VNF delay to weight (Check on correctness)
+            if(delay_calc):
+                vnf_delay = j.get_delay()
+                total_delay += vnf_delay
+
+
+            
             if j.end:
                 end_reached = True
             # switch direction to backward after last end component
@@ -63,7 +72,17 @@ class Template:
             if j.source:
                 if direction == "forward":
                     out_dr[(j, direction, 0)] = src_dr
+
                 continue
+
+            # Alternative version calculating delay for forward or backward directions 
+
+            # if direction == "forward": 
+            #     total_delay += j.get_delay()
+
+            # if direction == "backward": 
+            #     total_delay += j.get_delay()
+
 
             # forward direction refers to the ingoing data rates and includes end components
             if direction == "forward":
@@ -87,8 +106,13 @@ class Template:
                 # resource consumption
                 cpu = j.cpu_req(in_dr_fwd + in_dr_bwd)
                 mem = j.mem_req(in_dr_fwd + in_dr_bwd)
+                #print(j.print())
+                
                 total_cpu += cpu
                 total_mem += mem
+
+
+               
 
                 # compute outgoing data rates and store them in the dictionary (end components only have bwd outputs)
                 if j.end:
@@ -99,6 +123,7 @@ class Template:
                     out_drs = [j.outgoing(in_dr_fwd, k_out) for k_out in range(j.outputs)]
                     for k_out in range(j.outputs):
                         out_dr[(j, "forward", k_out)] = out_drs[k_out]
+            
 
             if direction == "backward":
                 # set ingoing data rates in forward direction to 0
@@ -121,18 +146,27 @@ class Template:
                 # resource consumption
                 cpu = j.cpu_req(in_dr_fwd + in_dr_bwd)
                 mem = j.mem_req(in_dr_fwd + in_dr_bwd)
+                # vnf_delay = j.get_delay()
                 total_cpu += cpu
                 total_mem += mem
+                # total_delay += vnf_delay
 
                 # compute outgoing data rates and store them in the dictionary
                 out_drs = [j.outgoing_back(in_dr_bwd, k_out) for k_out in range(j.outputs_back)]
                 for k_out in range(j.outputs_back):
                     out_dr[(j, "backward", k_out)] = out_drs[k_out]
+            # print ("Total Delay BWD")
+            # print (total_delay)
 
+        # print ("Total Delay")
+        # print (total_delay)
         total_dr = sum(out_dr.values())
         print("{}'s weight: {}\n".format(self, total_cpu+total_mem+total_dr))
-        return total_cpu + total_mem + total_dr
-
+        
+        if(delay_calc):
+            return total_cpu + total_mem + total_dr + total_delay
+        else:
+            return total_cpu + total_mem + total_dr
 
     # start with source component and continue breadth-first style (first forward then backward direction)
     # FUTURE WORK: set as property/constant such that it only has to be computed once (eg, in init)

--- a/src/bjointsp/template/template.py
+++ b/src/bjointsp/template/template.py
@@ -49,7 +49,7 @@ class Template:
         # iterate over components in topological order, determine outgoing dr for each and store it in out_dr
         # first, consider only forward direction then only backward
         # also determine cpu/mem consumption per component and direction and increase total_cpu/mem accordingly
-        total_cpu, total_mem = 0, 0, 
+        total_cpu, total_mem = 0, 0
         topo_order = self.topological_component_order()
         direction = "forward"
         end_reached = False


### PR DESCRIPTION
Specify, read, and consider VNF delays in total delay

With this PR:
* VNF delays can be specified in a template (optional; default = 0 delay)
* These are read and considered by B-JointSP when creating the components and when calculating the total delay in the objective value of a placement
* The vnf delay is separately saved in the written results