### PR TITLE
fixed bug with reading prev embedding from file

### DIFF
--- a/src/bjointsp/main.py
+++ b/src/bjointsp/main.py
@@ -61,7 +61,6 @@ def place(network_file, template_file, source_file, fixed_file=None, prev_embedd
 
     logger.info("Starting initial embedding at {}".format(timestamp))
     # print("Initial embedding\n")
-    # TODO: make less verbose or only as verbose when asked for (eg, with -v argument)
     init_time, runtime, obj_value, changed, overlays = control.solve(nodes, links, templates, prev_embedding, sources,
                                                                      fixed, obj)
     # If the write_result variable is True we receive the path to a result file

--- a/src/bjointsp/read_write/reader.py
+++ b/src/bjointsp/read_write/reader.py
@@ -249,6 +249,7 @@ def read_prev_placement(networkx, templates):
             # find component that matches the VNF name (in any of the templates)
             for t in templates:
                 # use first matching component (assuming it's only in one template)
+                # TODO: does this work as expected or do we need to pass vnf["name"] here too?
                 component = get_component(t, vnf)
                 if component is not None:
                     # add new instance to overlay of corresponding template (source components need src_flows being set)
@@ -278,7 +279,7 @@ def read_prev_embedding(file, templates, nodes, links):
             # find component that matches the VNF name (in any of the templates)
             for t in templates:
                 # use first matching component (assuming it's only in one template)
-                component = get_component(t, vnf)
+                component = get_component(t, vnf["name"])
                 if component is not None:
                     # add new instance to overlay of corresponding template (source components need src_flows being set)
                     if component.source:

--- a/src/bjointsp/read_write/reader.py
+++ b/src/bjointsp/read_write/reader.py
@@ -248,8 +248,7 @@ def read_prev_placement(networkx, templates):
         for vnf in node_attr['available_sf']:
             # find component that matches the VNF name (in any of the templates)
             for t in templates:
-                # use first matching component (assuming it's only in one template)
-                # TODO: does this work as expected or do we need to pass vnf["name"] here too?
+                # use first matching component (assuming it's only in one template); here, "vnf" is the vnf's name
                 component = get_component(t, vnf)
                 if component is not None:
                     # add new instance to overlay of corresponding template (source components need src_flows being set)


### PR DESCRIPTION
When specifying a previous embedding as a file, B-JointSP didn't match the VNFs to Template component's correctly such that reading the previous embedding always resulted in an empty embedding. This is fixed now.

The bug didn't exist when retrieving the previous embedding from a NetworkX object. So it doesn't affect https://github.com/RealVNF/bjointsp-adapter/issues/12 