### PR TITLE
allow fixed_vns to be specified as objects or files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='bjointsp',
-    version='2.4.1',
+    version='2.4.2',
     license='Apache 2.0',
     description='B-JointSP provides algorithms for joint scaling and placement of uni- or bidirectional network services',
     url='https://github.com/CN-UPB/B-JointSP',

--- a/src/bjointsp/main.py
+++ b/src/bjointsp/main.py
@@ -22,7 +22,8 @@ obj = objective.COMBINED
 # By Default we send the paths to the template_file as well as the source_file, but for being able to parallel run
 # multiple instances of BJointSP we want them to be objects. When sending source and template objects we also set
 # 'source_template_object' to True so that BJointSP is able to handle the difference
-def place(network_file, template_file, source_file, source_template_object=False, fixed_file=None,
+# fixed_vnfs may be a path to a file with fixed VNF instances or a list of dicts (containing the same info)
+def place(network_file, template_file, source_file, source_template_object=False, fixed_vnfs=None,
           prev_embedding_file=None, cpu=None, mem=None, dr=None, networkx=None, write_result=True):
     seed = random.randint(0, 9999)
     seed_subfolder = False
@@ -52,15 +53,15 @@ def place(network_file, template_file, source_file, source_template_object=False
     # exit()
     components = {j for t in templates for j in t.components}
     fixed = []
-    if fixed_file is not None:
-        fixed = reader.read_fixed_instances(fixed_file, components)
+    if fixed_vnfs is not None:
+        fixed = reader.read_fixed_instances(fixed_vnfs, components)
     prev_embedding = {}
     if networkx is not None:
         prev_embedding = reader.read_prev_placement(networkx, templates)
     elif prev_embedding_file is not None:
         prev_embedding = reader.read_prev_embedding(prev_embedding_file, templates, nodes, links)
 
-    input_files = [network_file, template_file, source_file, fixed_file, prev_embedding_file]
+    input_files = [network_file, template_file, source_file, fixed_vnfs, prev_embedding_file]
     # TODO: support >1 template
 
     # print("Using seed {}".format(seed))
@@ -94,7 +95,7 @@ def parse_args():
 
 def main():
     args = parse_args()
-    place(args.network, args.template, args.sources, fixed_file=args.fixed, prev_embedding_file=args.prev, cpu=10,
+    place(args.network, args.template, args.sources, fixed_vnfs=args.fixed, prev_embedding_file=args.prev, cpu=10,
           mem=10, dr=50)
 
 

--- a/src/bjointsp/read_write/reader.py
+++ b/src/bjointsp/read_write/reader.py
@@ -214,21 +214,26 @@ def read_sources(file, source_components, source_object=False):
     return sources
 
 
-# read fixed instances from yaml file
-def read_fixed_instances(file, components):
+# read fixed instances from yaml file or list of dicts (fixed_vnfs may be either or)
+def read_fixed_instances(fixed_vnfs, components):
+    assert isinstance(fixed_vnfs, str) or isinstance(fixed_vnfs, list)
     fixed_instances = []
-    with open(file, "r") as stream:
-        fixed = yaml.load(stream)
-        for i in fixed:
-            # get the component with the specified name: first (and only) element with component name
-            try:
-                component = list(filter(lambda x: x.name == i["vnf"], components))[0]
-                if component.source:
-                    raise ValueError("Component {} is a source component (forbidden).".format(component))
-            except IndexError:
-                raise ValueError("Component {} of fixed instance unknown (not used in any template).".format(i["vnf"]))
+    if isinstance(fixed_vnfs, list):
+        fixed = fixed_vnfs
+    else:
+        with open(fixed_vnfs, "r") as stream:
+            fixed = yaml.load(stream)
 
-            fixed_instances.append(FixedInstance(i["node"], component))
+    for i in fixed:
+        # get the component with the specified name: first (and only) element with component name
+        try:
+            component = list(filter(lambda x: x.name == i["vnf"], components))[0]
+            if component.source:
+                raise ValueError("Component {} is a source component (forbidden).".format(component))
+        except IndexError:
+            raise ValueError("Component {} of fixed instance unknown (not used in any template).".format(i["vnf"]))
+
+        fixed_instances.append(FixedInstance(i["node"], component))
     return fixed_instances
 
 

--- a/src/bjointsp/read_write/writer.py
+++ b/src/bjointsp/read_write/writer.py
@@ -187,7 +187,12 @@ def write_heuristic_result(runtime, obj_value, changed, overlays, input_files, o
 
     # set file of fixed instances and of previous embedding if they are specified
     if input_files[3] is not None:
-        result["input"]["fixed"] = os.path.basename(input_files[3])
+        # string path
+        if isinstance(input_files[3], str):
+            result["input"]["fixed"] = os.path.basename(input_files[3])
+        # list of dicts
+        else:
+            result["input"]["fixed"] = str(input_files[3])
     if input_files[4] is not None:
         result["input"]["prev_embedding"] = os.path.basename(input_files[4])
 


### PR DESCRIPTION
* Optional fixed VNFs can now also be specified as objects directly.
* Before, just file paths to yaml files were allowed.
* API doesn't change.
* B-JointSP detects whether it's a file path or object itself and proceeds accordingly
