### PR TITLE
allow setting custom cap attribute string for networkx objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ If you use B-JointSP in your research, please cite our work:
 
 ### Changelog
 
+* March 2020: Allowed passing template, sources, fixed VNFs as objects directly (not just file paths)
 * Feb 2019: Added end-to-end delay as result metric (not just total delay)
 * Feb 2019: Added VNF delays to templates and to calculation of total delay
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='bjointsp',
-    version='2.4.2',
+    version='2.4.3',
     license='Apache 2.0',
     description='B-JointSP provides algorithms for joint scaling and placement of uni- or bidirectional network services',
     url='https://github.com/CN-UPB/B-JointSP',

--- a/src/bjointsp/main.py
+++ b/src/bjointsp/main.py
@@ -23,8 +23,10 @@ obj = objective.COMBINED
 # multiple instances of BJointSP we want them to be objects. When sending source and template objects we also set
 # 'source_template_object' to True so that BJointSP is able to handle the difference
 # fixed_vnfs may be a path to a file with fixed VNF instances or a list of dicts (containing the same info)
+# optionally, networkx object can be passed directly and is used instead of the referenced network file
+# in that case, optionally specify a networkx_cap attribute string to retrieve the current node and link capacity
 def place(network_file, template_file, source_file, source_template_object=False, fixed_vnfs=None,
-          prev_embedding_file=None, cpu=None, mem=None, dr=None, networkx=None, write_result=True):
+          prev_embedding_file=None, cpu=None, mem=None, dr=None, networkx=None, networkx_cap='cap', write_result=True):
     seed = random.randint(0, 9999)
     seed_subfolder = False
     random.seed(seed)
@@ -39,7 +41,7 @@ def place(network_file, template_file, source_file, source_template_object=False
 
     # if a NetworkX object is passed, use that - including all of its capacities, delays, etc
     if networkx is not None:
-        nodes, links = reader.read_networkx(networkx)
+        nodes, links = reader.read_networkx(networkx, cap=networkx_cap)
     else:
         nodes, links = reader.read_network(network_file, cpu, mem, dr)
 

--- a/src/bjointsp/read_write/reader.py
+++ b/src/bjointsp/read_write/reader.py
@@ -49,15 +49,16 @@ def update_stateful(template):
 
 # same as read_network but use an already existing, annotated NetworkX object
 # this is highly tailored to the NetworkX objects created by https://github.com/RealVNF/coordination-simulation
-def read_networkx(networkx):
+# cap is the attribute string for capacity
+def read_networkx(networkx, cap='cap'):
     # read nodes: use same cap for cpu and mem (no distinction in the simulator)
     node_ids = [v for v in networkx.nodes.keys()]
-    node_cpu = {v[0]: v[1]['cap'] for v in networkx.nodes.data()}
+    node_cpu = {v[0]: v[1][cap] for v in networkx.nodes.data()}
     nodes = Nodes(node_ids, node_cpu, node_cpu.copy())
 
     # read edges
     link_ids = [e for e in networkx.edges.keys()]
-    link_dr = {(e[0], e[1]): e[2]['cap'] for e in networkx.edges.data()}
+    link_dr = {(e[0], e[1]): e[2][cap] for e in networkx.edges.data()}
     link_delay = {(e[0], e[1]): e[2]['delay'] for e in networkx.edges.data()}
 
     # add reversed links for bidirectionality


### PR DESCRIPTION
No breaking API changes

Example:

```python
result = bjointsp_place(self.network_path, template, source, source_template_object=True,
                        networkx=self.simulator.network, networkx_cap='remaining_cap', write_result=False)
```