### PR TITLE
Return None if no placement found

### DIFF
--- a/src/bjointsp/heuristic/control.py
+++ b/src/bjointsp/heuristic/control.py
@@ -189,6 +189,10 @@ def solve(arg_nodes, arg_links, templates, prev_overlays, sources, fixed, arg_ob
         logger.info("----- Iterative improvement -----")
         overlays = improvement.improve(arg_nodes, arg_links, templates, overlays, sources, fixed, shortest_paths,
                                        print_best=print_best)
+        # None = failure to place. shouldn't happen (unless there's no way to find a placement)
+        if overlays is None:
+            runtime = time.time() - start_heuristic
+            return init_time, runtime, math.inf, None, None
         obj_value = objective_value(overlays)
         runtime = time.time() - start_heuristic
         # print("Objective value after improvement: {}".format(obj_value))

--- a/src/bjointsp/heuristic/improvement.py
+++ b/src/bjointsp/heuristic/improvement.py
@@ -90,6 +90,9 @@ def improve(arg_nodes, arg_links, templates, arg_overlays, sources, fixed, arg_s
             reset_overlay(ol.template, rand_instance, modified_overlays)
             modified_overlays = heuristic.solve(nodes, links, templates, modified_overlays, sources, fixed,
                                                 shortest_paths, tabu)
+            # return failed placement back to controller. to fail in "save" way
+            if modified_overlays is None:
+                return None
 
             # update solution
             new_obj_value = control.objective_value(modified_overlays)

--- a/src/bjointsp/heuristic/shortest_paths.py
+++ b/src/bjointsp/heuristic/shortest_paths.py
@@ -1,4 +1,7 @@
 import math
+import logging
+
+logger = logging.getLogger('bjointsp')
 
 
 # return the delay of the specified path (= list of nodes)
@@ -8,7 +11,11 @@ def path_delay(links, path):
     for i in range(len(path) - 1):
         # skip connections on same node without a link (both inst at same node)
         if path[i] != path[i + 1]:
-            delay += links.delay[(path[i], path[i+1])]
+            if (path[i], path[i+1]) in links.delay:
+                delay += links.delay[(path[i], path[i+1])]
+            else:
+                logger.warning(f'No link {(path[i], path[i+1])}. Setting infinite delay.')
+                return math.inf
     return delay
 
 

--- a/src/bjointsp/main.py
+++ b/src/bjointsp/main.py
@@ -74,6 +74,9 @@ def place(network_file, template_file, source_file, source_template_object=False
     # print("Initial embedding\n")
     init_time, runtime, obj_value, changed, overlays = control.solve(nodes, links, templates, prev_embedding, sources,
                                                                      fixed, obj, print_best=print_best)
+    if overlays is None:
+        logger.error("Could not find placement. Returning None.")
+        return None
     # If the write_result variable is True we receive the path to a result file
     # If the write_result variable is False we a result dict.
     result = writer.write_heuristic_result(runtime, obj_value, changed, overlays.values(), input_files, obj, nodes,


### PR DESCRIPTION
* If no placement can be found, eg, because there are no candidate nodes within the delay bound, BJointSP used to just crash
* Now it logs an error and returns None but doesn't crash